### PR TITLE
Fix tailwindcss postcss plugin reference

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 }

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,6 +1,6 @@
 const config = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- use `@tailwindcss/postcss` plugin in postcss config files

## Testing
- `npm run build` *(fails: missing build script)*

------
https://chatgpt.com/codex/tasks/task_e_684a70390988832fa736890434f57069